### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/src/neuroca/db/connections/mongo.py
+++ b/src/neuroca/db/connections/mongo.py
@@ -104,8 +104,8 @@ class MongoDBConnection:
         # Validate configuration
         self._validate_config()
         
-        logger.debug("MongoDB connection manager initialized with config: %s", 
-                    {k: v if k != 'password' else '******' for k, v in self.config.items()})
+        logger.debug("MongoDB connection manager initialized with sanitized config: %s", 
+                    self._sanitize_config(self.config))
 
     def _load_config_from_env(self) -> dict[str, Any]:
         """
@@ -172,6 +172,19 @@ class MongoDBConnection:
         # If username is provided, password should also be provided
         if self.config.get('username') and not self.config.get('password'):
             logger.warning("MongoDB username provided without password. Authentication may fail.")
+
+    def _sanitize_config(self, config: dict[str, Any]) -> dict[str, Any]:
+        """
+        Sanitize the configuration dictionary by removing sensitive keys.
+        
+        Args:
+            config (dict[str, Any]): The original configuration dictionary.
+        
+        Returns:
+            dict[str, Any]: A sanitized configuration dictionary with sensitive keys removed.
+        """
+        sensitive_keys = {'password', 'username', 'auth_source', 'auth_mechanism'}
+        return {k: v for k, v in config.items() if k not in sensitive_keys}
 
     def _build_connection_uri(self) -> str:
         """


### PR DESCRIPTION
Potential fix for [https://github.com/Modern-Prometheus-AI/Neuroca/security/code-scanning/3](https://github.com/Modern-Prometheus-AI/Neuroca/security/code-scanning/3)

To fix the issue, we will ensure that no sensitive data is logged. Instead of logging the entire configuration dictionary, we will log only non-sensitive keys or a sanitized version of the configuration. This approach ensures that sensitive information, such as passwords, is never exposed in logs, even inadvertently.

1. Modify the logging statement on line 108 to exclude sensitive keys entirely, rather than masking them.
2. Define a helper function to sanitize the configuration dictionary by removing sensitive keys before logging.
3. Update the logger to use the sanitized configuration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
