### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/src/neuroca/api/middleware/__init__.py
+++ b/src/neuroca/api/middleware/__init__.py
@@ -101,7 +101,7 @@ def setup_trusted_hosts(app: FastAPI) -> None:
             TrustedHostMiddleware,
             allowed_hosts=settings.TRUSTED_HOSTS,
         )
-        logger.debug("Trusted hosts middleware configured with hosts: %s", settings.TRUSTED_HOSTS)
+        logger.debug("Trusted hosts middleware has been configured.")
 
 
 def setup_compression(app: FastAPI) -> None:


### PR DESCRIPTION
Potential fix for [https://github.com/Modern-Prometheus-AI/Neuroca/security/code-scanning/2](https://github.com/Modern-Prometheus-AI/Neuroca/security/code-scanning/2)

To fix the issue, we should avoid logging the contents of `settings.TRUSTED_HOSTS` directly. Instead, we can log a generic message indicating that the trusted hosts middleware has been configured without exposing the actual values. This ensures that no sensitive data is logged while still providing useful debugging information.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
