### PR TITLE
Potential fix for code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/src/neuroca/db/connections/mongo.py
+++ b/src/neuroca/db/connections/mongo.py
@@ -104,8 +104,7 @@ class MongoDBConnection:
         # Validate configuration
         self._validate_config()
         
-        logger.debug("MongoDB connection manager initialized with sanitized config: %s", 
-                    self._sanitize_config(self.config))
+        # MongoDB connection manager initialized. Configuration details are not logged to avoid exposing sensitive data.
 
     def _load_config_from_env(self) -> dict[str, Any]:
         """


### PR DESCRIPTION
Potential fix for [https://github.com/Modern-Prometheus-AI/Neuroca/security/code-scanning/4](https://github.com/Modern-Prometheus-AI/Neuroca/security/code-scanning/4)

To address the issue, we will remove the `logger.debug` statement on line 108 that logs the sanitized configuration. This ensures that no configuration data, sanitized or otherwise, is logged. Logging configuration data, even in sanitized form, is unnecessary and poses a potential security risk. By eliminating this logging statement, we prevent any possibility of sensitive data being exposed in the logs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
